### PR TITLE
Opprettet ny enum GrunnlagRequestType

### DIFF
--- a/src/main/kotlin/no/nav/bidrag/behandling/felles/enums/GrunnlagRequestType.kt
+++ b/src/main/kotlin/no/nav/bidrag/behandling/felles/enums/GrunnlagRequestType.kt
@@ -1,0 +1,13 @@
+package no.nav.bidrag.behandling.felles.enums
+
+/**
+ * Typer grunnlag som kan innhentes av tjenesten bidrag-grunnlag.
+ * Brukes for å spesifisere hvilke grunnlag man ønsker at skal innhentes for en grunnlagspakke.
+ * Må ikke forveksles med GrunnlagType.
+ */
+enum class GrunnlagRequestType {
+  AINNTEKT,
+  SKATTEGRUNNLAG,
+  UTVIDETBARNETRYGDOGSMAABARNSTILLEGG,
+  BARNETILLEG;
+}

--- a/src/main/kotlin/no/nav/bidrag/behandling/felles/enums/GrunnlagType.kt
+++ b/src/main/kotlin/no/nav/bidrag/behandling/felles/enums/GrunnlagType.kt
@@ -1,5 +1,8 @@
 package no.nav.bidrag.behandling.felles.enums
 
+/**
+ * Typer grunnlag som benyttes i beregning og vedtak
+ */
 enum class GrunnlagType(val value: String) {
   SAERFRADRAG(GrunnlagTypeConstants.SAERFRADRAG),
   SOKNADSBARN_INFO(GrunnlagTypeConstants.SOKNADSBARN_INFO),


### PR DESCRIPTION
* Trukket ut grunnlagstypene man kan be om å få innhentet fra bidrag-grunnlag til egen enum `GrunnlagRequestType`. Det var vanskelig å finne et fornuftig navn her så om du har et bedre forslag rop ut 😄 
* Med 2 enums blander vi ikke bruksområdene